### PR TITLE
Remove spelling mistake from README.md; closes #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,5 +107,5 @@ If you find an issue yourself you can report it, a community member will get bac
 3. Do not report issues which are previously reported by others. (Please check the closed issues too before you report an issue). 
 4. Do not suggest completely new developments in the issue list. (Please use the mailing list for this kind of suggestions. Use issue list to suggest bugs/features in the already implemented sections.)
 5. If an issue is reported by a person, it is automatically assigned to that person
-6. Use meaningful commit messages and sqaush all your commits into one
+6. Use meaningful commit messages and squash all your commits into one
 7. Only pick the issues which are labeled as free


### PR DESCRIPTION
![remove-spelling-mistake](https://cloud.githubusercontent.com/assets/16403502/21911598/2070f3a8-d92a-11e6-91e5-3bc9a3efdc89.jpg)
