### PR TITLE
Added dependencies to install shell script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,26 @@
+# install php7 and mysql
+sudo apt-get install php7.0 php7.0-fpm php7.0-mysql -y
+
+# install composer
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php -r "if (hash_file('SHA384', 'composer-setup.php') === '669656bab3166a7aff8a7506b8cb2d1c292f042046c5a994c43155c0be6190fa0355160742ab2e1c88d40d5be660b410') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+php composer-setup.php
+php -r "unlink('composer-setup.php');"
+
+#install node and npm
+sudo apt-get install nodejs npm
+
+# install npm gulp cli globally
+npm install -g gulp-cli
+
+# installing packages using composer
 composer update
+
+# installing packages using npm (such as gulp)
 npm install
+
+# Changing permissions of cache directory
 sudo chmod -R 777 cache/
+
+# running gulp tasks
 gulp

--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,15 @@
 # install php7 and mysql
 sudo apt-get install php7.0 php7.0-fpm php7.0-mysql -y
 
-# install composer
+# install composer, a package dependency manager
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('SHA384', 'composer-setup.php') === '669656bab3166a7aff8a7506b8cb2d1c292f042046c5a994c43155c0be6190fa0355160742ab2e1c88d40d5be660b410') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 php composer-setup.php
 php -r "unlink('composer-setup.php');"
 
-# install node and npm
+# install node and npm for minification of css
 sudo apt-get install nodejs npm
 
-# install npm gulp cli globally
+# install npm gulp cli globally for css minification
 npm install -g gulp-cli
 
 # installing packages using composer
@@ -22,5 +21,5 @@ npm install
 # Changing permissions of cache directory
 sudo chmod -R 777 cache/
 
-# running gulp tasks
+# running gulp tasks for minifying css
 gulp

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ php -r "if (hash_file('SHA384', 'composer-setup.php') === '669656bab3166a7aff8a7
 php composer-setup.php
 php -r "unlink('composer-setup.php');"
 
-#install node and npm
+# install node and npm
 sudo apt-get install nodejs npm
 
 # install npm gulp cli globally


### PR DESCRIPTION
Fixed installation issues for all platforms. 
Resolved issues with bash on Ubuntu on Windows and it is running now. Faced a lot of issues while installing php7 as the plugins were not installing automatically, and many of them were missing. Composer had a dependency on them, thus it was behaving differently. Another issue was instead of downloading & unpacking the packages, it was cloning the repositories of the packages as php7 dependencies were not met. Another issue was cli was not installed globally by default.
I identified these issues, found solutions and added them to bash install file.

![install](https://user-images.githubusercontent.com/13470643/28836999-1608ec54-76a0-11e7-9345-3bb917657b16.PNG)

