### PR TITLE
Refactoring  circle_of_trust.js and added Javascript Unit Tests for the same

### DIFF
--- a/includes/page_top.php
+++ b/includes/page_top.php
@@ -3,6 +3,8 @@
     $page_request = $_GET['page_request'] ?? \FirstAide\Router::INDEX;
     $query = $_GET['query'] ?? '';
     $page = FirstAide\Router::getPage($UserObj, $page_request, $query);
+    
+    $page['javascripts'][] = 'error.js';
 
 if ($page['type'] == FirstAide\Router::INDEX) {
     $page['javascripts'][] = 'validation.js';

--- a/includes/page_top.php
+++ b/includes/page_top.php
@@ -19,14 +19,14 @@ if ($page['type'] == FirstAide\Router::INDEX) {
         <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
 
         <!-- Site Properities -->
-        <title><?php echo isset($_page['title']) ? $_page['title'].' | ' : ''  ?>FirstAide, Peacecorps</title>
+        <title><?php echo (isset($page['title']) ? $page['title'].' | ' : '');  ?>FirstAide, Peacecorps</title>
         <?php
-        echo isset($_page['description']) ?
-            '<meta name="description" content="'.$_page['description'].'" />' :
+        echo isset($page['description']) ?
+            '<meta name="description" content="'.$page['description'].'" />' :
             '' ?>
         <?php
-        echo isset($_page['keywords']) ?
-        '<meta name="keywords" content="'.$_page['keywords'].'"
+        echo isset($page['keywords']) ?
+        '<meta name="keywords" content="'.$page['keywords'].'"
         />' : '' ?>
 
         <link rel="stylesheet" type="text/css" class="ui" href="stylesheets/min/semantic.min.css">

--- a/js/circle_of_trust.js
+++ b/js/circle_of_trust.js
@@ -1,14 +1,3 @@
-function showError(ele, msg) {
-    ele.addClass('error');
-    ele.find('.ui.red.pointing').text(msg);
-    ele.find('.ui.red.pointing').show();
-    setTimeout(function() {ele.find('.ui.red').hide();}, 7000);
-}
-function hideError(ele) {
-    ele.removeClass('error');
-    ele.find('.ui.red.pointing').hide();
-}
-
 function showResponse(response, pageReload) {
     if (typeof pageReload === 'undefined') { pageReload = true; }
     if (!response.response) {
@@ -25,15 +14,14 @@ function showResponse(response, pageReload) {
     }
 }
 
-$(document).ready(function() {
-    $('button').attr("disabled", false);
+function placeCircleOfTrustIcons() {
     //circle type - 1 whole, 0.5 half, 0.25 quarter
     var type = 1,
         //distance from center
         radius = '200%',
         //shift start from 0
         start = -90,
-        $elements = $('li:not(:first-child)'),
+        $elements = $('.circle li:not(:first-child)'),
         //For even distro of elements of comrades
         numberOfElements = (type === 1) ?  $elements.length : $elements.length - 1, 
         slice = 360 * type / numberOfElements;
@@ -47,28 +35,46 @@ $(document).ready(function() {
             'transform': 'rotate(' + rotate + 'deg) translate(' + radius + ') rotate(' + rotateReverse + 'deg)'
         });
     });
+}
 
+function toggleCircleOfTrustSections(action) {
     var circleOfTrust = $('.circle-of-trust-page .circle-of-trust'),
         editComrades = $('.circle-of-trust-page .edit-comrades-section'),
         comradeAction = $('.circle-of-trust-page .comrade-action-section');
 
 
-    circleOfTrust.fadeIn();
-    $('.icon.angle.left').on('click', function() {
+    if (action === 'back') {
         editComrades.fadeOut('slow');
         comradeAction.fadeOut('slow');
         circleOfTrust.delay(500).fadeIn('slow');
-    })
-    $('.icon.edit').on('click', function() {
+    } else if (action === 'edit') {
         comradeAction.fadeOut('slow');
         circleOfTrust.fadeOut('slow');
         editComrades.delay(500).fadeIn('slow');
-    });
-    $('.get-help-button').on('click', function() {
+    } else if (action === 'help') {
         circleOfTrust.fadeOut('slow');
         editComrades.fadeOut('slow');
         comradeAction.delay(500).fadeIn('slow');
+    }
+}
+
+$(document).ready(function() {
+    $('button').attr("disabled", false);
+
+    placeCircleOfTrustIcons();
+    $('.circle-of-trust-page .circle-of-trust').fadeIn();
+    $('.icon.angle.left').on('click', function() {
+        toggleCircleOfTrustSections('back');
     });
+
+    $('.icon.edit').on('click', function() {
+        toggleCircleOfTrustSections('edit');
+    });
+
+    $('.get-help-button').on('click', function() {
+        toggleCircleOfTrustSections('help');
+    });
+
     $('.comrade-form .submit').on('click', function(e) {
         e.preventDefault();
         var comradesData = [],
@@ -116,12 +122,10 @@ $(document).ready(function() {
     });
 
     $('.comrade-action-button').on('click', function() {
-        console.log($(this).attr('id'));
         var postData = {
             type: 'send_sms_circle_of_trust',
             msg_type: $(this).attr('id')
         }
-        console.log(postData);
         try {
             $.ajax({
                 url: 'request/send_notification.php',

--- a/js/circle_of_trust.js
+++ b/js/circle_of_trust.js
@@ -4,19 +4,21 @@
  * @response{dictionary} contains ajax call response
  * @pageReload{bool value} used to determine if the page needs to be loaded or not based on the response
  */
-function showResponse(response, pageReload) {
-    if (typeof pageReload === 'undefined') { pageReload = true; }
-    if (!response.response) {
-        $('.ui.modal').find('.header').text('Are you lost?');
-    } else {
-        $('.ui.modal').find('.header').text('Reloading');
-    }
-    $('.ui.modal').find('.content').text(response.message);
-    $('.ui.modal').modal('show');
-    if (pageReload) {
-        setTimeout(function() {
-            location.reload();
-        }, 4000);
+function showResponseModal(response, pageReload) {
+    if (typeof response !== 'undefined') {
+        if (typeof pageReload === 'undefined') { pageReload = true; }
+        if (!response.response) {
+            $('.ui.modal').find('.header').text('Are you lost?');
+        } else {
+            $('.ui.modal').find('.header').text('Reloading');
+        }
+        $('.ui.modal').find('.content').text(response.message);
+        $('.ui.modal').modal('show');
+        if (pageReload) {
+            setTimeout(function() {
+                location.reload();
+            }, 4000);
+        }
     }
 }
 

--- a/js/circle_of_trust.js
+++ b/js/circle_of_trust.js
@@ -1,3 +1,9 @@
+/**
+ * showResponse() displays a modal on receiving response
+ *
+ * @response{dictionary} contains ajax call response
+ * @pageReload{bool value} used to determine if the page needs to be loaded or not based on the response
+ */
 function showResponse(response, pageReload) {
     if (typeof pageReload === 'undefined') { pageReload = true; }
     if (!response.response) {
@@ -14,6 +20,10 @@ function showResponse(response, pageReload) {
     }
 }
 
+/**
+ * placeCircleOfTrustIcons() used to place all the comrade icons in a circle
+ *
+ */
 function placeCircleOfTrustIcons() {
     //circle type - 1 whole, 0.5 half, 0.25 quarter
     var type = 1,
@@ -37,6 +47,11 @@ function placeCircleOfTrustIcons() {
     });
 }
 
+/**
+ * toggleCircleOfTrustSections() used to toggle views between circle of trust section, edit comrades details section and get help via sms section
+ *
+ * @action{string} determines the action based on which the view is rendered
+ */
 function toggleCircleOfTrustSections(action) {
     var circleOfTrust = $('.circle-of-trust-page .circle-of-trust'),
         editComrades = $('.circle-of-trust-page .edit-comrades-section'),
@@ -57,6 +72,7 @@ function toggleCircleOfTrustSections(action) {
         comradeAction.delay(500).fadeIn('slow');
     }
 }
+
 
 $(document).ready(function() {
     $('button').attr("disabled", false);

--- a/js/error.js
+++ b/js/error.js
@@ -1,0 +1,29 @@
+/**
+ * showError() displays error divisions
+ * with given message(msg)
+ * for a short span of time inside given element
+ *
+ * @element {DOM element} element in which error will be shown
+ * @msg {string} The message to be displayed for the error
+ */
+function showError(element, msg) {
+	if (typeof element !== 'undefined') {
+		element.addClass('error');
+		element.find('.ui.red.pointing').text(msg);
+		element.find('.ui.red.pointing').show();
+		setTimeout(function() {element.find('.ui.red').hide();}, 7000);
+	}
+}
+
+/**
+ * hideError() hides error divisions
+ * inside given element
+ *
+ * @element {DOM element} element where the error will be hidden
+ */
+function hideError(element) {
+	if (typeof element !== 'undefined') {
+		element.removeClass('error');
+		element.find('.ui.red.pointing').hide();
+	}
+}

--- a/js/index.js
+++ b/js/index.js
@@ -1,34 +1,4 @@
 /**
- * showError() displays error divisions
- * with given message(msg)
- * for a short span of time inside given element
- *
- * @element {DOM element} element in which error will be shown
- * @msg {string} The message to be displayed for the error
- */
-function showError(element, msg) {
-	if (typeof element !== 'undefined') {
-		element.addClass('error');
-		element.find('.ui.red.pointing').text(msg);
-		element.find('.ui.red.pointing').show();
-		setTimeout(function() {element.find('.ui.red').hide();}, 7000);
-	}
-}
-
-/**
- * hideError() hides error divisions
- * inside given element
- *
- * @element {DOM element} element where the error will be hidden
- */
-function hideError(element) {
-	if (typeof element !== 'undefined') {
-		element.removeClass('error');
-		element.find('.ui.red.pointing').hide();
-	}
-}
-
-/**
  * notEmpty() checks if the given input field is empty
  *
  * @elementData {dictionary} contains field element to check

--- a/modules/Router.php
+++ b/modules/Router.php
@@ -198,6 +198,12 @@ class Router
             $countries = file_get_contents($APPLICATION_DIR.self::COUNTRY_LIST_FILE);
             $out['country_list'] = json_decode($countries, true);
         }
+        if (isset($out['content']['data']['title']) || isset($out['content']['data']['card_content']['data']['title'])) {
+            $out['title'] = $out['content']['data']['title']
+                ?? ($out['content']['data']['card_content']['data']['title']
+                    ?? $out['title']
+                );
+        }
         return $out;
     }
 

--- a/modules/Router.php
+++ b/modules/Router.php
@@ -198,7 +198,9 @@ class Router
             $countries = file_get_contents($APPLICATION_DIR.self::COUNTRY_LIST_FILE);
             $out['country_list'] = json_decode($countries, true);
         }
-        if (isset($out['content']['data']['title']) || isset($out['content']['data']['card_content']['data']['title'])) {
+        if (isset($out['content']['data']['title'])
+            || isset($out['content']['data']['card_content']['data']['title'])
+        ) {
             $out['title'] = $out['content']['data']['title']
                 ?? ($out['content']['data']['card_content']['data']['title']
                     ?? $out['title']

--- a/tests/jsTests/circleOfTrustsSpec.js
+++ b/tests/jsTests/circleOfTrustsSpec.js
@@ -1,0 +1,207 @@
+/**
+ * Suite : Tests for success response modal
+ * Description : This is a test suite for checking when the response is a success
+ */
+describe("Tests for success response modal", function() {
+	var msg = 'This is a test message when the response is a success';
+	beforeEach(function() {
+		jasmine.clock().install();
+		setFixtures('<div class="element"></div>\
+		<div class="processing"></div>\
+		<div class="ui modal">\
+			<div class="header"></div>\
+			<div class="content"></div>\
+			<div class="actions">\
+				<div class="ui cancel green button">Close</div>\
+			</div>\
+		</div>');
+		$('.ui.modal').hide();
+
+		// mock modal show call
+		spyOn($.fn, "modal").and.returnValue($('.ui.modal').show());
+		showResponse($('element'), { response: true, message: msg });
+		jasmine.clock().tick(4000);
+	});
+
+	afterEach(function() {
+		jasmine.clock().uninstall();
+	});
+
+	it("should be visible", function() {
+		expect($('.content')).toContainText(msg);
+		expect($('.ui.modal')).toBeVisible();
+	});
+});
+
+/**
+ * Suite : Tests for failed response modal
+ * Description : This is a test suite for a failed response modal
+ */
+describe("Tests for failed response modal", function() {
+	var msg = 'This is a test message for a failed response modal';
+	beforeEach(function() {
+		jasmine.clock().install();
+		setFixtures('<div class="element"></div>\
+		<div class="ui modal">\
+			<div class="header"></div>\
+			<div class="content"></div>\
+			<div class="actions">\
+				<div class="ui cancel green button">Close</div>\
+			</div>\
+		</div>');
+		$('.ui.modal').hide();
+
+		// mock modal show call
+		spyOn($.fn, "modal").and.returnValue($('.ui.modal').show());
+		showResponse($('element'), { response: false, message: msg });
+		jasmine.clock().tick(4000);
+	});
+
+	afterEach(function() {
+		jasmine.clock().uninstall();
+	});
+
+	it("should be visible", function() {
+		expect($('.content')).toContainText(msg);
+		expect($('.header')).toContainText('Are you lost?');
+		expect($('.ui.modal')).toBeVisible();
+	});
+});
+
+/**
+ * Suite : Tests for showing error on incorrect field entry
+ * Description : This is a test suite for showing error in case of an invalid field entry
+ */
+describe("Tests to place circle of trust icons in circle", function() {
+	beforeEach(function() {
+		jasmine.clock().install();
+		setFixtures('<div class="circle"> \
+				<ul> \
+					<li>first</li> \
+					<li>second</li> \
+					<li>third</li> \
+					<li>fourth</li> \
+					<li>fifth</li> \
+					<li>sixth</li> \
+					<li>seventh</li> \
+				</ul> \
+			</div>');
+		placeCircleOfTrustIcons();
+		jasmine.clock().tick(4000);
+	});
+
+	it("b", function() {
+		expect($('.circle li')[1].style.webkitTransform).toBe('rotate(-90deg) translate(200%) rotate(90deg)');
+		expect($('.circle li')[2].style.webkitTransform).toBe('rotate(-30deg) translate(200%) rotate(30deg)');
+		expect($('.circle li')[3].style.webkitTransform).toBe('rotate(30deg) translate(200%) rotate(-30deg)');
+		expect($('.circle li')[4].style.webkitTransform).toBe('rotate(90deg) translate(200%) rotate(-90deg)');
+		expect($('.circle li')[5].style.webkitTransform).toBe('rotate(150deg) translate(200%) rotate(-150deg)');
+		expect($('.circle li')[6].style.webkitTransform).toBe('rotate(210deg) translate(200%) rotate(-210deg)');
+	});
+
+	afterEach(function() {
+		jasmine.clock().uninstall();
+	});
+});
+
+/**
+ * Suite : Tests for showing error on incorrect field entry
+ * Description : This is a test suite for showing error in case of an invalid field entry
+ */
+describe("Tests to show circle of trust icons", function() {
+	var msg = 'This is a test message for showing error';
+	beforeEach(function() {
+		jasmine.clock().install();
+		setFixtures('<div class="circle-of-trust-page"> \
+				<div class="circle-of-trust"></div> \
+				<div class="edit-comrades-section"></div> \
+				<div class="comrade-action-section"></div> \
+			</div>');
+		spyOn($.fn, "fadeOut").and.callFake(function() {
+			$(this).hide();
+		});
+		spyOn($.fn, "fadeIn").and.callFake(function() {
+			$(this).show();
+		});
+        toggleCircleOfTrustSections('back');
+		jasmine.clock().tick(4000);
+	});
+
+	it("back button clicked", function() {
+		expect($('.circle-of-trust-page .edit-comrades-section')).toBeHidden();
+		expect($('.circle-of-trust-page .comrade-action-section')).toBeHidden();
+		expect($('.circle-of-trust-page .circle-of-trust')).toBeVisible();
+	});
+
+	afterEach(function() {
+		jasmine.clock().uninstall();
+	});
+});
+
+/**
+ * Suite : Tests for showing error on incorrect field entry
+ * Description : This is a test suite for showing error in case of an invalid field entry
+ */
+describe("Tests to show edit circle of trust section", function() {
+	var msg = 'This is a test message for showing error';
+	beforeEach(function() {
+		jasmine.clock().install();
+		setFixtures('<div class="circle-of-trust-page"> \
+				<div class="circle-of-trust"></div> \
+				<div class="edit-comrades-section"></div> \
+				<div class="comrade-action-section"></div> \
+			</div>');
+		spyOn($.fn, "fadeOut").and.callFake(function() {
+			$(this).hide();
+		});
+		spyOn($.fn, "fadeIn").and.callFake(function() {
+			$(this).show();
+		});
+        toggleCircleOfTrustSections('edit');
+		jasmine.clock().tick(4000);
+	});
+
+	it("edit button clicked", function() {
+		expect($('.circle-of-trust-page .edit-comrades-section')).toBeVisible();
+		expect($('.circle-of-trust-page .comrade-action-section')).toBeHidden();
+		expect($('.circle-of-trust-page .circle-of-trust')).toBeHidden();
+	});
+
+	afterEach(function() {
+		jasmine.clock().uninstall();
+	});
+});
+
+/**
+ * Suite : Tests for showing error on incorrect field entry
+ * Description : This is a test suite for showing error in case of an invalid field entry
+ */
+describe("Tests to show get help section", function() {
+	var msg = 'This is a test message for showing error';
+	beforeEach(function() {
+		jasmine.clock().install();
+		setFixtures('<div class="circle-of-trust-page"> \
+				<div class="circle-of-trust"></div> \
+				<div class="edit-comrades-section"></div> \
+				<div class="comrade-action-section"></div> \
+			</div>');
+		spyOn($.fn, "fadeOut").and.callFake(function() {
+			$(this).hide();
+		});
+		spyOn($.fn, "fadeIn").and.callFake(function() {
+			$(this).show();
+		});
+        toggleCircleOfTrustSections('help');
+		jasmine.clock().tick(4000);
+	});
+
+	it("get help button clicked", function() {
+		expect($('.circle-of-trust-page .edit-comrades-section')).toBeHidden();
+		expect($('.circle-of-trust-page .comrade-action-section')).toBeVisible();
+		expect($('.circle-of-trust-page .circle-of-trust')).toBeHidden();
+	});
+
+	afterEach(function() {
+		jasmine.clock().uninstall();
+	});
+});

--- a/tests/jsTests/circleOfTrustsSpec.js
+++ b/tests/jsTests/circleOfTrustsSpec.js
@@ -21,6 +21,7 @@ describe("Tests for success response modal", function() {
 		// mock modal show call
 		spyOn($.fn, "modal").and.returnValue($('.ui.modal').show());
 		showResponse($('element'), { response: true, message: msg });
+		// creating delay of 400ms
 		jasmine.clock().tick(4000);
 	});
 
@@ -56,6 +57,7 @@ describe("Tests for failed response modal", function() {
 		// mock modal show call
 		spyOn($.fn, "modal").and.returnValue($('.ui.modal').show());
 		showResponse($('element'), { response: false, message: msg });
+		// creating delay of 400ms
 		jasmine.clock().tick(4000);
 	});
 
@@ -89,10 +91,11 @@ describe("Tests to place circle of trust icons in circle", function() {
 				</ul> \
 			</div>');
 		placeCircleOfTrustIcons();
+		// creating delay of 400ms
 		jasmine.clock().tick(4000);
 	});
 
-	it("b", function() {
+	it("should transform elements", function() {
 		expect($('.circle li')[1].style.webkitTransform).toBe('rotate(-90deg) translate(200%) rotate(90deg)');
 		expect($('.circle li')[2].style.webkitTransform).toBe('rotate(-30deg) translate(200%) rotate(30deg)');
 		expect($('.circle li')[3].style.webkitTransform).toBe('rotate(30deg) translate(200%) rotate(-30deg)');
@@ -160,6 +163,7 @@ describe("Tests to show edit circle of trust section", function() {
 			$(this).show();
 		});
         toggleCircleOfTrustSections('edit');
+		// creating delay of 400ms
 		jasmine.clock().tick(4000);
 	});
 
@@ -194,6 +198,7 @@ describe("Tests to show get help section", function() {
 			$(this).show();
 		});
         toggleCircleOfTrustSections('help');
+		// creating delay of 400ms
 		jasmine.clock().tick(4000);
 	});
 

--- a/tests/jsTests/circleOfTrustsSpec.js
+++ b/tests/jsTests/circleOfTrustsSpec.js
@@ -236,7 +236,7 @@ describe("Tests to show get help section", function() {
 		jasmine.clock().tick(4000);
 	});
 
-	it("get help button clicked", function() {
+	it("get help button clicked and update comrades detail section made visible", function() {
 		expect($('.circle-of-trust-page .edit-comrades-section')).toBeHidden();
 		expect($('.circle-of-trust-page .comrade-action-section')).toBeVisible();
 		expect($('.circle-of-trust-page .circle-of-trust')).toBeHidden();

--- a/tests/jsTests/circleOfTrustsSpec.js
+++ b/tests/jsTests/circleOfTrustsSpec.js
@@ -1,6 +1,7 @@
 /**
  * Suite : Tests for success response modal
- * Description : This is a test suite for checking when the response is a success
+ * Description : This is a test suite for checking for a modal (a prompt)
+ * when the response is a success
  */
 describe("Tests for success response modal", function() {
 	var msg = 'This is a test message when the response is a success';
@@ -36,6 +37,7 @@ describe("Tests for success response modal", function() {
 /**
  * Suite : Tests for failed response modal
  * Description : This is a test suite for a failed response modal
+ * in case of a failure
  */
 describe("Tests for failed response modal", function() {
 	var msg = 'This is a test message for a failed response modal';
@@ -69,8 +71,8 @@ describe("Tests for failed response modal", function() {
 });
 
 /**
- * Suite : Tests for showing error on incorrect field entry
- * Description : This is a test suite for showing error in case of an invalid field entry
+ * Suite : Tests to place circle of trust icons in circle
+ * Description : This is a test suite for checking if all the icons in the circle of trust are placed in a circle
  */
 describe("Tests to place circle of trust icons in circle", function() {
 	beforeEach(function() {
@@ -105,8 +107,8 @@ describe("Tests to place circle of trust icons in circle", function() {
 });
 
 /**
- * Suite : Tests for showing error on incorrect field entry
- * Description : This is a test suite for showing error in case of an invalid field entry
+ * Suite : Tests to show circle of trust icons
+ * Description : This is a validating if all the icons of circle of trust are placed in a circle
  */
 describe("Tests to show circle of trust icons", function() {
 	var msg = 'This is a test message for showing error';

--- a/tests/jsTests/circleOfTrustsSpec.js
+++ b/tests/jsTests/circleOfTrustsSpec.js
@@ -20,7 +20,8 @@ describe("Tests for success response modal", function() {
 
 		// mock modal show call
 		spyOn($.fn, "modal").and.returnValue($('.ui.modal').show());
-		showResponse($('element'), { response: true, message: msg });
+		showResponseModal({ response: true, message: msg }, false);
+
 		// creating delay of 400ms
 		jasmine.clock().tick(4000);
 	});
@@ -56,7 +57,8 @@ describe("Tests for failed response modal", function() {
 
 		// mock modal show call
 		spyOn($.fn, "modal").and.returnValue($('.ui.modal').show());
-		showResponse($('element'), { response: false, message: msg });
+		showResponseModal({ response: false, message: msg }, false);
+
 		// creating delay of 400ms
 		jasmine.clock().tick(4000);
 	});
@@ -69,6 +71,38 @@ describe("Tests for failed response modal", function() {
 		expect($('.content')).toContainText(msg);
 		expect($('.header')).toContainText('Are you lost?');
 		expect($('.ui.modal')).toBeVisible();
+	});
+});
+
+/**
+ * Suite : Tests for undefined response
+ * Description : This is a test suite for a undefined response
+ * in case of a failure
+ */
+describe("Tests for undefined response", function() {
+	var msg = 'This is a test message for a failed response modal';
+	beforeEach(function() {
+		jasmine.clock().install();
+		setFixtures('<div class="element"></div>\
+		<div class="ui modal">\
+			<div class="header"></div>\
+			<div class="content"></div>\
+			<div class="actions">\
+				<div class="ui cancel green button">Close</div>\
+			</div>\
+		</div>');
+		$('.ui.modal').hide();
+
+		showResponseModal();
+		jasmine.clock().tick(4000);
+	});
+
+	afterEach(function() {
+		jasmine.clock().uninstall();
+	});
+
+	it("should be visible", function() {
+		expect($('.ui.modal')).toBeHidden();
 	});
 });
 

--- a/tests/jsTests/errorSpec.js
+++ b/tests/jsTests/errorSpec.js
@@ -25,7 +25,7 @@ describe("Tests for showing error on incorrect field entry", function() {
 describe("Tests for hiding error on correct field entry", function() {
 	var msg = 'This is a test message for not showing error';
 	beforeEach(function() {
-		setFixtures('<div class="field"> \
+		setFixtures('<div class="field error"> \
 				<div class="ui red pointing">' + msg + '</div> \
 			</div>');
 		hideError($('.field'));

--- a/tests/jsTests/errorSpec.js
+++ b/tests/jsTests/errorSpec.js
@@ -1,0 +1,38 @@
+/**
+ * Suite : Tests for showing error on incorrect field entry
+ * Description : This is a test suite for showing error in case of an invalid field entry
+ */
+describe("Tests for showing error on incorrect field entry", function() {
+	var msg = 'This is a test message for showing error';
+	beforeEach(function() {
+		setFixtures('<div class="field"> \
+				<div class="ui red pointing"></div> \
+			</div>');
+		showError($('.field'), msg);
+	});
+
+	it("should be visible", function() {
+		expect($('.field')).toHaveClass('error');
+		expect($('.ui.red.pointing')).toContainText(msg);
+		expect($('.ui.red.pointing')).toBeVisible();
+	});
+});
+
+/**
+ * Suite : Tests for hiding error on correct field entry
+ * Description : This is a test suite for hiding error in case of an valid field entry
+ */
+describe("Tests for hiding error on correct field entry", function() {
+	var msg = 'This is a test message for not showing error';
+	beforeEach(function() {
+		setFixtures('<div class="field"> \
+				<div class="ui red pointing">' + msg + '</div> \
+			</div>');
+		hideError($('.field'));
+	});
+
+	it("should be visible", function() {
+		expect($('.field')).not.toHaveClass('error');
+		expect($('.ui.red.pointing')).toBeHidden();
+	});
+});

--- a/tests/jsTests/indexSpec.js
+++ b/tests/jsTests/indexSpec.js
@@ -1,43 +1,4 @@
 /**
- * Suite : Tests for showing error on incorrect field entry
- * Description : This is a test suite for showing error in case of an invalid field entry
- */
-describe("Tests for showing error on incorrect field entry", function() {
-	var msg = 'This is a test message for showing error';
-	beforeEach(function() {
-		setFixtures('<div class="field"> \
-				<div class="ui red pointing"></div> \
-			</div>');
-		showError($('.field'), msg);
-	});
-
-	it("should be visible", function() {
-		expect($('.field')).toHaveClass('error');
-		expect($('.ui.red.pointing')).toContainText(msg);
-		expect($('.ui.red.pointing')).toBeVisible();
-	});
-});
-
-/**
- * Suite : Tests for hiding error on correct field entry
- * Description : This is a test suite for hiding error in case of an valid field entry
- */
-describe("Tests for hiding error on correct field entry", function() {
-	var msg = 'This is a test message for not showing error';
-	beforeEach(function() {
-		setFixtures('<div class="field"> \
-				<div class="ui red pointing">' + msg + '</div> \
-			</div>');
-		hideError($('.field'));
-	});
-
-	it("should be visible", function() {
-		expect($('.field')).not.toHaveClass('error');
-		expect($('.ui.red.pointing')).toBeHidden();
-	});
-});
-
-/**
  * Suite : Tests for not empty field
  * Description : This is a test suite for checking when field is not empty
  */


### PR DESCRIPTION
This includes the following:
-  Refactoring of index.js to make it more modular.
-  Specs and test suites mocking methods through fixtures for circle_of_trust.js.
-  Block comments with each test suite name and description.
-  Separation of errorSpec.js from indexSpec.js 

![selection_006](https://user-images.githubusercontent.com/13470643/29472797-dabafb2a-8472-11e7-9900-2d542407d328.png)
